### PR TITLE
Removed reference to Deprecation Notice

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -1,7 +1,5 @@
 import SnowflakeApp from '../components/SnowflakeApp'
-import DeprecationNotice from '../components/DeprecationNotice'
 
 export default () => <div>
-  <DeprecationNotice />
   <SnowflakeApp />
 </div>


### PR DESCRIPTION
It was required in the index.js which caused localhost to error as it
was looking for Deprecation component that was removed in 1st commit.